### PR TITLE
Edited html5.js to remove volume control in android

### DIFF
--- a/src/js/control-bar/control-bar.js
+++ b/src/js/control-bar/control-bar.js
@@ -8,24 +8,7 @@
  */
 vjs.ControlBar = vjs.Component.extend();
 
-// hide volume control and mute toggle if ios and android devices
-if(vjs.IS_IOS || vjs.IS_ANDROID){
-	vjs.ControlBar.prototype.options_ = {
-  loadEvent: 'play',
-  children: {
-    'playToggle': {},
-    'currentTimeDisplay': {},
-    'timeDivider': {},
-    'durationDisplay': {},
-    'remainingTimeDisplay': {},
-    'progressControl': {},
-    'fullscreenToggle': {}
-    // 'volumeMenuButton': {}
-  }
-};
-}
-else {
-	vjs.ControlBar.prototype.options_ = {
+vjs.ControlBar.prototype.options_ = {
   loadEvent: 'play',
   children: {
     'playToggle': {},
@@ -40,7 +23,6 @@ else {
     // 'volumeMenuButton': {}
   }
 };
-}
 
 vjs.ControlBar.prototype.createEl = function(){
   return vjs.createEl('div', {

--- a/src/js/media/html5.js
+++ b/src/js/media/html5.js
@@ -254,9 +254,11 @@ vjs.Html5.canPlaySource = function(srcObj){
 };
 
 vjs.Html5.canControlVolume = function(){
-  var volume =  vjs.TEST_VID.volume;
-  vjs.TEST_VID.volume = (volume / 2) + 0.1;
-  return volume !== vjs.TEST_VID.volume;
+	var volume =  vjs.TEST_VID.volume;
+	vjs.TEST_VID.volume = (volume / 2) + 0.1;
+	// iOS can't control volume but Android can
+	// but we also have to remove it on Android
+	return volume !== vjs.TEST_VID.volume && !vjs.IS_ANDROID;
 };
 
 // List of all HTML5 events (various uses).


### PR DESCRIPTION
Edited the html5.js instead of control-bar.js to remove volume control in android and ios devices.
